### PR TITLE
Remove deprecated "bottle :unneeded"

### DIFF
--- a/lawsg.rb
+++ b/lawsg.rb
@@ -4,8 +4,6 @@ class Lawsg < Formula
   url "https://github.com/mmcquillan/lawsg/releases/download/v0.4.0/lawsg-0.4.0.tar.gz"
   sha256 "d9fe4a12f80012643c4f0955ad53d4c38fdf63af7f4b7cc2675a52ae236b2863"
 
-  bottle :unneeded
-
   def install
     bin.install "lawsg"
   end

--- a/protocli.rb
+++ b/protocli.rb
@@ -4,8 +4,6 @@ class Protocli < Formula
   url "https://github.com/mmcquillan/protocli/releases/download/v0.2.0/protocli-0.2.0.tar.gz"
   sha256 "d741e33d8b669e3519a335d030c3f389b98ec251f437cc3ee92385d1f4368b25"
 
-  bottle :unneeded
-
   def install
     bin.install "protocli"
   end


### PR DESCRIPTION
Removed in [`brew` 3.2.1](https://github.com/Homebrew/brew/releases/tag/3.2.1).